### PR TITLE
Fix the About Section's buttons' chaotic behaviour

### DIFF
--- a/content/pages/index.html
+++ b/content/pages/index.html
@@ -117,25 +117,19 @@
                 </div>
             </div>
             <!-- Call to action btns -->
-            <div class="col-3">
+            <div class="col-3 action-btn-small-container">
                 <a href="http://kiwitcms.readthedocs.io/en/latest/installing_docker.html" class="action-btn-small accent-medium">
                     <p><i class="fa fa-cloud-download-alt fa-5x"></i></p>
                     <h3>Get Started</h3>
                 </a>
-            </div>
-            <div class="col-3">
                 <a href="http://kiwitcms.readthedocs.io" class="action-btn-small accent-medium">
                     <p><i class="fa fa-book fa-5x"></i></p>
                     <h3>Documentation</h3>
                 </a>
-            </div>
-            <div class="col-3">
                 <a href="{filename}community.markdown" class="action-btn-small accent-medium">
                     <p><i class="fa fa-users fa-5x"></i></p>
                     <h3>Community</h3>
                 </a>
-            </div>
-            <div class="col-3">
                 <a href="http://mrsenko.com" class="action-btn-small accent-medium">
                     <p><i class="fa fa-headphones fa-5x"></i></p>
                     <h3>Support</h3>

--- a/theme/static/style/style.css
+++ b/theme/static/style/style.css
@@ -296,8 +296,14 @@ pre code {
 }
 
 .action-btn-small {
-    text-align: center;
     padding: 1rem;
+    display: inline-block;
+    width: 22%;
+}
+
+.action-btn-small-container {
+    width: inherit;
+    text-align: center;
 }
 
 /* About Section */
@@ -670,14 +676,10 @@ pre code {
         font-size: 2.25rem;
         line-height: 2.5rem;
     }
-    .col-3 .fa-5x {
-        font-size: 15rem;
-    }
-    .col-3 h3 {
-        font-size: 3.5rem;
-        line-height: 4rem;
-    }
 
+    .about .action-btn-small-container {
+        width: inherit;
+    }
 
     /* Screenshots section */
     .screenshots .col-2, .img-index {
@@ -765,6 +767,11 @@ pre code {
 
     .about-panel-details {
         padding-right: 1.8rem;
+    }
+
+    /*about section*/
+    .action-btn-small {
+        display: initial;
     }
 
     /* screenshot section and features page */


### PR DESCRIPTION
- Prevent them from switching places
- Align them to the bottom center of the section
- Fixes #35